### PR TITLE
【Fixed】rails g の際に無駄にhelperとassetsが生成されないようにしました。

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,10 @@ module Dive23
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    config.generators do |g|
+      g.assets     false
+      g.helper     false
+    end
   end
 end


### PR DESCRIPTION
#1 
config/application.rbに設定を行いました。