### PR TITLE
【Fixed】デバッグツールを導入する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,3 +43,9 @@ group :development, :test do
   gem 'spring'
 end
 
+group :development do
+  gem 'pry-rails'
+  gem 'better_errors'
+  gem 'binding_of_caller'
+end
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,10 +37,15 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     arel (6.0.3)
+    better_errors (2.1.1)
+      coderay (>= 1.0.0)
+      erubis (>= 2.6.6)
+      rack (>= 0.9.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
     byebug (9.0.5)
+    coderay (1.1.1)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.1.x)
@@ -67,6 +72,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
+    method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
@@ -78,6 +84,12 @@ GEM
       pkg-config (~> 1.1.7)
     pg (0.18.4)
     pkg-config (1.1.7)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-rails (0.3.4)
+      pry (>= 0.9.10)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -118,6 +130,7 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    slop (3.6.0)
     spring (1.7.2)
     sprockets (3.7.0)
       concurrent-ruby (~> 1.0)
@@ -146,11 +159,14 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  better_errors
+  binding_of_caller
   byebug
   coffee-rails (~> 4.1.0)
   jbuilder (~> 2.0)
   jquery-rails
   pg
+  pry-rails
   rails (= 4.2.3)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,4 +38,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+  
+  BetterErrors::Middleware.allow_ip! "0.0.0.0/0"
+  
 end


### PR DESCRIPTION
#2 

Gemfileに追記。
group :development do
　gem 'pry-rails'
　gem 'better_errors'
　gem 'binding_of_caller'
end

better_errorsの初期設定のため、
config/environments/development.rbに、以下を記述。
BetterErrors::Middleware.allow_ip! "0.0.0.0/0"
