### PR TITLE
【Fixed】ユーザー(users)と回答(answers)間の関連を設定

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,3 +1,4 @@
 class Answer < ActiveRecord::Base
   belongs_to :question
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
          
+  has_many :answers
   has_many :questions
   has_many :favorites
   has_many :votes

--- a/db/migrate/20160821073010_create_answers.rb
+++ b/db/migrate/20160821073010_create_answers.rb
@@ -2,7 +2,7 @@ class CreateAnswers < ActiveRecord::Migration
   def change
     create_table :answers do |t|
       t.references :question, index: true, foreign_key: true
-      t.integer :user_id
+      t.references :user, index: true, foreign_key: true
       t.text :content, null: false
       t.string :photo
       t.integer :posi_counts, default: 0

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 20160821074134) do
   end
 
   add_index "answers", ["question_id"], name: "index_answers_on_question_id", using: :btree
+  add_index "answers", ["user_id"], name: "index_answers_on_user_id", using: :btree
 
   create_table "favorites", force: :cascade do |t|
     t.integer  "user_id"
@@ -108,6 +109,7 @@ ActiveRecord::Schema.define(version: 20160821074134) do
   add_index "votes", ["user_id"], name: "index_votes_on_user_id", using: :btree
 
   add_foreign_key "answers", "questions"
+  add_foreign_key "answers", "users"
   add_foreign_key "favorites", "questions"
   add_foreign_key "favorites", "users"
   add_foreign_key "questions", "users"

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -3,5 +3,6 @@ require 'rails_helper'
 RSpec.describe Answer, type: :model do
   describe 'Association' do
     it { should belong_to(:question) }
+    it { should belong_to(:user) }
   end    
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   describe 'Association' do
+    it { should have_many(:answers) }
     it { should have_many(:favorites) }
     it { should have_many(:votes) }
   end


### PR DESCRIPTION
issues#46

- [x] ユーザー(users)と回答(answers)間に１対ｎの関連を設定
- [x] Rspecによるテストによって関連が正しく設定された事を確認する。