### PR TITLE
【Fixed】回答(answers)と投票(votes)間の関連を設定

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,4 +1,5 @@
 class Answer < ActiveRecord::Base
   belongs_to :question
   belongs_to :user
+  has_many :votes
 end

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -1,4 +1,5 @@
 class Vote < ActiveRecord::Base
+  belongs_to :answer
   belongs_to :question
   belongs_to :user
 end

--- a/db/migrate/20160821074134_create_votes.rb
+++ b/db/migrate/20160821074134_create_votes.rb
@@ -3,7 +3,7 @@ class CreateVotes < ActiveRecord::Migration
     create_table :votes do |t|
       t.references :user, index: true, foreign_key: true
       t.references :question, index: true, foreign_key: true
-      t.integer :answer_id
+      t.references :answer, index: true, foreign_key: true
       t.boolean :is_positive, null: false, default: false
       t.boolean :deleted_flg, null: false, default: false
       t.timestamps null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -105,6 +105,7 @@ ActiveRecord::Schema.define(version: 20160821074134) do
     t.datetime "updated_at",                  null: false
   end
 
+  add_index "votes", ["answer_id"], name: "index_votes_on_answer_id", using: :btree
   add_index "votes", ["question_id"], name: "index_votes_on_question_id", using: :btree
   add_index "votes", ["user_id"], name: "index_votes_on_user_id", using: :btree
 
@@ -113,6 +114,7 @@ ActiveRecord::Schema.define(version: 20160821074134) do
   add_foreign_key "favorites", "questions"
   add_foreign_key "favorites", "users"
   add_foreign_key "questions", "users"
+  add_foreign_key "votes", "answers"
   add_foreign_key "votes", "questions"
   add_foreign_key "votes", "users"
 end

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -4,5 +4,6 @@ RSpec.describe Answer, type: :model do
   describe 'Association' do
     it { should belong_to(:question) }
     it { should belong_to(:user) }
+    it { should have_many(:votes) }
   end    
 end

--- a/spec/models/vote_spec.rb
+++ b/spec/models/vote_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Vote, type: :model do
   describe 'Association' do
+    it { should belong_to(:answer) }
     it { should belong_to(:question) }
     it { should belong_to(:user) }
   end    


### PR DESCRIPTION
issues#43

- [ ] 回答(answers)と投票(votes)間に１対ｎの関連を設定
- [ ] Rspecによるテストによって関連が正しく設定された事を確認する。