### PR TITLE
【Fixed】質問(qusetions)とタグ関連(tag_relations)間のrelationを設定する

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -3,6 +3,7 @@ class Question < ActiveRecord::Base
   has_many   :favorites
   has_many   :answers
   has_many   :votes
+  has_many   :tag_relations
   
   validates_presence_of :title, :content, :user_id
 end

--- a/app/models/tag_relation.rb
+++ b/app/models/tag_relation.rb
@@ -1,2 +1,3 @@
 class TagRelation < ActiveRecord::Base
+  belongs_to :question
 end

--- a/db/migrate/20160821060841_create_tag_relations.rb
+++ b/db/migrate/20160821060841_create_tag_relations.rb
@@ -1,7 +1,7 @@
 class CreateTagRelations < ActiveRecord::Migration
   def change
     create_table :tag_relations do |t|
-      t.integer :question_id
+      t.references :question, index: true, foreign_key: true
       t.integer :tag_id
       t.boolean :deleted_flg, null: false, default: false
       t.timestamps null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -65,6 +65,8 @@ ActiveRecord::Schema.define(version: 20160821074134) do
     t.datetime "updated_at",                  null: false
   end
 
+  add_index "tag_relations", ["question_id"], name: "index_tag_relations_on_question_id", using: :btree
+
   create_table "tags", force: :cascade do |t|
     t.string   "name",        default: "",    null: false
     t.boolean  "deleted_flg", default: false, null: false
@@ -114,6 +116,7 @@ ActiveRecord::Schema.define(version: 20160821074134) do
   add_foreign_key "favorites", "questions"
   add_foreign_key "favorites", "users"
   add_foreign_key "questions", "users"
+  add_foreign_key "tag_relations", "questions"
   add_foreign_key "votes", "answers"
   add_foreign_key "votes", "questions"
   add_foreign_key "votes", "users"

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Question, type: :model do
     it { should have_many(:favorites) }
     it { should have_many(:answers) }
     it { should have_many(:votes) }
+    it { should have_many(:tag_relations) }
   end
 
 end

--- a/spec/models/tag_relation_spec.rb
+++ b/spec/models/tag_relation_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe TagRelation, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'Association' do
+    it { should belong_to(:question) }
+  end
 end


### PR DESCRIPTION
issues#32

- [x] 質問(qusetions)とタグ関連(tag_relations)に１対ｎのrelationを設定する。
- [x] Rspecによる単体テストで関連が正しく設定されている事を確認する。