### PR TITLE
質問(questions)の削除を物理削除から論理削除に変更する

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -38,7 +38,8 @@ class QuestionsController < ApplicationController
   end
 
   def destroy
-    @question.destroy
+    @question.deleted_flg = true
+    @question.save
     respond_to do |format|
       format.html { redirect_to questions_url, notice: 'Question was successfully destroyed.' }
     end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -6,4 +6,6 @@ class Question < ActiveRecord::Base
   has_many   :tag_relations
   
   validates_presence_of :title, :content, :user_id
+  
+  default_scope -> { where(deleted_flg: false) }
 end


### PR DESCRIPTION
issues#63

- [ ] 質問(questions)を物理削除から論理削除に変える
- [ ] 質問の参照系の処理はdeleted_flgがfalseの物だけを参照する。（deleted状態のデータも参照したい場合は除く）