### PR TITLE
【Fixed】質問の単体テストクラス(question_spec.rb)の記述ミスの修正

### DIFF
--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Question, type: :model do
     end
     
     #ユーザIDが記入されていなければNG
-    it "is invalid without content" do
+    it "is invalid without user_id" do
       question = build(:question)
       expect(question).not_to be_valid
     end


### PR DESCRIPTION
#52 
記述ミスを修正しました。

修正前）
#ユーザIDが記入されていなければNG
it "is invalid without content"

修正後）
#ユーザIDが記入されていなければNG
it "is invalid without user_id"