### PR TITLE
【Fixed】質問(question)コントローラに操作権限の設定を行う

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   
   before_action :configure_permitted_parameters, if: :devise_controller?
-
+  before_action :authenticate_user!  
 
  PERMISSIBLE_ATTRIBUTES = %i(avatar avatar_cache)
 

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -14,6 +14,9 @@ class QuestionsController < ApplicationController
   end
 
   def edit
+    unless check_mine?
+      redirect_to :questions, notice: '編集権限がありません' #TODO m.kitamura メッセージ定義
+    end
   end
 
   def create
@@ -29,20 +32,28 @@ class QuestionsController < ApplicationController
   end
 
   def update
-    respond_to do |format|
-      if @question.update(question_params)
-        format.html { redirect_to @question, notice: 'Question was successfully updated.' }
-      else
-        format.html { render :edit }
+    if check_mine?
+      respond_to do |format|
+        if @question.update(question_params)
+          format.html { redirect_to @question, notice: 'Question was successfully updated.' }
+        else
+          format.html { render :edit }
+        end
       end
+    else
+      redirect_to :questions, notice: '編集権限がありません' #TODO m.kitamura メッセージ定義
     end
   end
 
   def destroy
-    @question.deleted_flg = true
-    @question.save
-    respond_to do |format|
-      format.html { redirect_to questions_url, notice: 'Question was successfully destroyed.' }
+    if check_mine?
+      @question.deleted_flg = true
+      @question.save
+      respond_to do |format|
+        format.html { redirect_to questions_url, notice: 'Question was successfully destroyed.' }
+      end
+    else
+      redirect_to :questions, notice: '編集権限がありません' #TODO m.kitamura メッセージ定義
     end
   end
 
@@ -53,5 +64,13 @@ class QuestionsController < ApplicationController
 
     def question_params
       params.require(:question).permit(:user_id, :title, :content, :photo, :favorite_counts, :posi_counts, :nega_counts, :deleted_flg)
+    end
+
+    def check_mine?
+      if @question.user.id == current_user.id
+        true
+      else
+        false
+      end
     end
 end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,6 +1,6 @@
 class QuestionsController < ApplicationController
   before_action :set_question, only: [:show, :edit, :update, :destroy]
-  skip_before_action :authenticate_user!, only: [:index]
+  skip_before_action :authenticate_user!, only: [:index, :show]
 
   def index
     @questions = Question.all

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,5 +1,6 @@
 class QuestionsController < ApplicationController
   before_action :set_question, only: [:show, :edit, :update, :destroy]
+  skip_before_action :authenticate_user!, only: [:index]
 
   def index
     @questions = Question.all

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -29,8 +29,10 @@
         <td><%= question.nega_counts %></td>
         <td><%= question.deleted_flg %></td>
         <td><%= link_to 'Show', question %></td>
-        <td><%= link_to 'Edit', edit_question_path(question) %></td>
-        <td><%= link_to 'Destroy', question, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% if question.user.id == current_user.id %>
+          <td><%= link_to 'Edit', edit_question_path(question) %></td>
+          <td><%= link_to 'Destroy', question, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      <% end %>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -29,7 +29,7 @@
         <td><%= question.nega_counts %></td>
         <td><%= question.deleted_flg %></td>
         <td><%= link_to 'Show', question %></td>
-        <% if question.user.id == current_user.id %>
+        <% if current_user && question.user.id == current_user.id %>
           <td><%= link_to 'Edit', edit_question_path(question) %></td>
           <td><%= link_to 'Destroy', question, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       <% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -76,12 +76,12 @@ ActiveRecord::Schema.define(version: 20160821074134) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "",    null: false
-    t.string   "encrypted_password",     default: "",    null: false
+    t.string   "email",                  default: "", null: false
+    t.string   "encrypted_password",     default: "", null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,     null: false
+    t.integer  "sign_in_count",          default: 0,  null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.inet     "current_sign_in_ip"
@@ -89,10 +89,8 @@ ActiveRecord::Schema.define(version: 20160821074134) do
     t.string   "name"
     t.string   "avatar"
     t.text     "profile"
-    t.integer  "score",                  default: 0,     null: false
-    t.boolean  "deleted_flg",            default: false, null: false
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -76,12 +76,12 @@ ActiveRecord::Schema.define(version: 20160821074134) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
+    t.string   "email",                  default: "",    null: false
+    t.string   "encrypted_password",     default: "",    null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer  "sign_in_count",          default: 0,     null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.inet     "current_sign_in_ip"
@@ -89,8 +89,10 @@ ActiveRecord::Schema.define(version: 20160821074134) do
     t.string   "name"
     t.string   "avatar"
     t.text     "profile"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
+    t.integer  "score",                  default: 0,     null: false
+    t.boolean  "deleted_flg",            default: false, null: false
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree


### PR DESCRIPTION
#61

- 質問の閲覧は誰でも可
  - QuestionsControllerのindexアクションとshowアクションはauthenticate_user!によるフィルタをスキップ
- 質問の投稿は、ログインユーザのみ可
  - ApplicationControllerにフィルタとしてauthenticate_user!を追加
- 自分の質問のみ、編集・削除可
  - 自分の質問のみ編集・削除のリンクを表示するようビューを修正
  - 自分の質問以外の編集・削除リクエストがサーバに送られた際、処理をせず、質問一覧画面へリダイレクトする処理を追加