### PR TITLE
【Fixed】質問画面の調整（user_idのセットと画面表示項目の調整） 

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -18,10 +18,10 @@ class QuestionsController < ApplicationController
   end
 
   def create
-    @question = Question.new(question_params)
+    @question = current_user.questions.build(question_params)
     respond_to do |format|
       if @question.save
-        format.html { redirect_to @question, notice: 'Question was successfully created.' }
+        format.html { redirect_to @question, notice: '質問を投稿しました。' }
       else
         format.html { render :new }
       end
@@ -31,7 +31,7 @@ class QuestionsController < ApplicationController
   def update
     respond_to do |format|
       if @question.update(question_params)
-        format.html { redirect_to @question, notice: 'Question was successfully updated.' }
+        format.html { redirect_to @question, notice: '質問を更新しました。' }
       else
         format.html { render :edit }
       end
@@ -42,7 +42,7 @@ class QuestionsController < ApplicationController
     @question.deleted_flg = true
     @question.save
     respond_to do |format|
-      format.html { redirect_to questions_url, notice: 'Question was successfully destroyed.' }
+      format.html { redirect_to questions_url, notice: '質問を削除しました。' }
     end
   end
 

--- a/app/views/questions/_form.html.erb
+++ b/app/views/questions/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for(question) do |f| %>
+<%= form_for(question, :html => {:class => "form-horizontal"}) do |f| %>
   <% if question.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(question.errors.count, "error") %> prohibited this question from being saved:</h2>
@@ -10,23 +10,14 @@
       </ul>
     </div>
   <% end %>
-
-  <div class="field">
-    <%= f.label :user_id %>
-    <%= f.number_field :user_id %>
+  <div class="form-group">
+    <%= f.label :タイトル,class: 'control-label' %>
+    <%= f.text_field :title, class: 'form-control' %>
   </div>
-
-  <div class="field">
-    <%= f.label :title %>
-    <%= f.text_field :title %>
+  <div class="form-group">
+    <%= f.text_area :content, class: 'form-control' %>
   </div>
-
-  <div class="field">
-    <%= f.label :content %>
-    <%= f.text_area :content %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit %>
+  <div class="form-group">
+    <%= f.submit :class => 'btn btn-info' %>
   </div>
 <% end %>

--- a/app/views/questions/edit.html.erb
+++ b/app/views/questions/edit.html.erb
@@ -1,6 +1,1 @@
-<h1>Editing Question</h1>
-
 <%= render 'form', question: @question %>
-
-<%= link_to 'Show', @question %> |
-<%= link_to 'Back', questions_path %>

--- a/app/views/questions/new.html.erb
+++ b/app/views/questions/new.html.erb
@@ -1,5 +1,1 @@
-<h1>New Question</h1>
-
 <%= render 'form', question: @question %>
-
-<%= link_to 'Back', questions_path %>


### PR DESCRIPTION
issues#85

・質問画面から画面タイトルと不要なボタンを削除。
・user_idを内部でセット。
・質問詳細画面の調整は別issue。(issue#30 回答(answers)用のViewを作成 )
・画面レイアウト、タグの関連付け機能、CSS等の詳細なデザインは別イシューで。