### PR TITLE
【Fixed】質問一覧画面(TOP画面)の調整（画面表示項目の調整等） 

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -4,7 +4,11 @@ class QuestionsController < ApplicationController
   skip_before_action :authenticate_user!, only: [:index, :show]
 
   def index
-    @questions = Question.all
+    if (params[:tab] == "active")
+      @questions = Question.all.order(updated_at: :desc) #TODO n.uchiyama 紐づくanswersの更新日時とソート順を考慮する必要あり
+    else
+      @questions = Question.all.order(favorite_counts: :desc, updated_at: :desc) #TODO n.uchiyama 紐づくanswersの更新日時とソート順を考慮する必要あり
+    end
   end
 
   def show

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -4,10 +4,13 @@ class QuestionsController < ApplicationController
   skip_before_action :authenticate_user!, only: [:index, :show]
 
   def index
-    if (params[:tab] == "active")
+    case params[:tab] 
+    when "active"
       @questions = Question.all.order(updated_at: :desc) #TODO n.uchiyama 紐づくanswersの更新日時とソート順を考慮する必要あり
-    else
+    when "favorite"
       @questions = Question.all.order(favorite_counts: :desc, updated_at: :desc) #TODO n.uchiyama 紐づくanswersの更新日時とソート順を考慮する必要あり
+    else
+      @questions = Question.all.order(updated_at: :desc)
     end
   end
 

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -1,43 +1,36 @@
-
-
-<h1>Questions</h1>
-
-<table>
-  <thead>
-    <tr>
-      <th>User</th>
-      <th>Title</th>
-      <th>Content</th>
-      <th>Photo</th>
-      <th>Favorite counts</th>
-      <th>Posi counts</th>
-      <th>Nega counts</th>
-      <th>Deleted flg</th>
-      <th colspan="3"></th>
-    </tr>
-  </thead>
-
-  <tbody>
+<div class="row">
+  <div class="col-sm-9">
+    <ul class="nav nav-tabs">
+      <li class="pull-right <%= 'active' if params[:tab] == 'favorite' %>"><%= link_to '人気', questions_path(tab: :favorite) %></li>
+      <li class="pull-right <%= 'active' if params[:tab] == 'active' or current_page?(root_path) %>"><%= link_to 'アクティブ', questions_path(tab: :active) %></li>
+    </ul>
     <% @questions.each do |question| %>
-      <tr>
-        <td><%= question.user_id %></td>
-        <td><%= question.title %></td>
-        <td><%= question.content %></td>
-        <td><%= question.photo %></td>
-        <td><%= question.favorite_counts %></td>
-        <td><%= question.posi_counts %></td>
-        <td><%= question.nega_counts %></td>
-        <td><%= question.deleted_flg %></td>
-        <td><%= link_to 'Show', question %></td>
-        <% if current_user && question.user.id == current_user.id %>
-          <td><%= link_to 'Edit', edit_question_path(question) %></td>
-          <td><%= link_to 'Destroy', question, method: :delete, data: { confirm: 'Are you sure?' } %></td>
-      <% end %>
-      </tr>
+      <div class="row">
+        <div class="col-sm-1">
+          <%= question.posi_counts - question.nega_counts %>
+          <p>票</p>
+        </div>
+        <div class="col-sm-1">
+          <%= question.answers.count %>
+          <p>回答</p>
+        </div>
+        <div class="col-sm-2">
+          <%= question.favorite_counts %>
+          <p>お気に入り</p>
+        </div>
+        <div class="col-sm-6">
+          <%= link_to question.title, question %> <%# TODO n.uchiyama 本家の真似をするならここに関連するTagを表示 %> 
+        </div>
+        <div class="col-sm-2">
+          <%= question.user.name %>
+          <%= question.user.score %>
+        </div>
+      </div>
+      <%# TODO n.uchiyama 質問の編集・削除は詳細画面の実装が済み次第そちらへ移動する。 %> 
+      <%# <% if current_user && question.user.id == current_user.id %> 
+      <%# <%= link_to 'Edit', edit_question_path(question) %>
+      <%# <%= link_to 'Destroy', question, method: :delete, data: { confirm: '削除しますか？' } %>
+      <%# <% end %>
     <% end %>
-  </tbody>
-</table>
-
-<br>
-
-<%= link_to 'New Question', new_question_path %>
+  </div>
+</div>


### PR DESCRIPTION
issues#88

・質問一覧画面(TOP画面)から不要な項目とボタンを削除しグリッドシステムを導入。
・タブによるソート順の切り替えを実装。（更新日時降順、お気に入り降順）
・このissueではおおまかな画面の調整を行う。CSS等の詳細なデザインは別イシューで。