### PR TITLE
avatorのリサイズ方式をresize_to_fitをresize_to_fillに変える 

### DIFF
--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -5,14 +5,14 @@ class AvatarUploader < BaseUploader
   process :resize_to_limit => [200, 200]
   
   version :small do
-    process :resize_to_fit => [32, 32]
+    process :resize_to_fill => [32, 32]
   end
 
   version :medium do
-    process :resize_to_fit => [48, 48]
+    process :resize_to_fill => [48, 48]
   end
 
   version :large do
-    process :resize_to_fit => [164, 164]
+    process :resize_to_fill => [164, 164]
   end
 end


### PR DESCRIPTION
issues#123

幾つかの画像を試した結果resize_to_fillが良かったので
resize_to_fitからresize_to_fillへ変換方式を変える。