### PR TITLE
【Fixed】favorites_controller_spec.rb中身を削除

### DIFF
--- a/spec/controllers/favorites_controller_spec.rb
+++ b/spec/controllers/favorites_controller_spec.rb
@@ -1,19 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe FavoritesController, type: :controller do
-
-  describe "GET #create" do
-    it "returns http success" do
-      get :create
-      expect(response).to have_http_status(:success)
-    end
-  end
-
-  describe "GET #destroy" do
-    it "returns http success" do
-      get :destroy
-      expect(response).to have_http_status(:success)
-    end
-  end
-
 end


### PR DESCRIPTION
issues#121

以下の内容を、rails g controllerの際に自動生成されたもののため、削除。
describe "GET #create" do
it "returns http success" do
get :create
expect(response).to have_http_status(:success)
end
end

describe "GET #destroy" do
it "returns http success" do
get :destroy
expect(response).to have_http_status(:success)
end
end
