### PR TITLE
【Fixed】お気に入りの登録・削除時にquesitonsのfavorite_countsを増減させる。

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -3,12 +3,19 @@ class FavoritesController < ApplicationController
     @favorite = current_user.favorites.build
     @favorite.question_id = params[:question_id]
     @question = @favorite.question
+    @question.favorite_counts += 1
     
     respond_to do |format|
-      if @favorite.save
+      begin
+        ActiveRecord::Base.transaction do
+          @favorite.save!
+          @question.save!
+        end
         format.html { redirect_to question_path(@question), notice: 'お気に入り登録しました。' }
-      else
+      rescue => e
         format.html { redirect_to question_path(@question), notice: 'お気に入り登録できませんでした。' }
+        Rails.logger.error e.message
+        Rails.logger.error e.backtrace.join("\n")
       end
     end
   end
@@ -16,10 +23,20 @@ class FavoritesController < ApplicationController
   def destroy
     @favorite = Favorite.find(params[:id])
     @question = Question.find(params[:question_id])
-    @favorite.destroy
+    @question.favorite_counts -= 1
     
     respond_to do |format|
-      format.html { redirect_to question_path(@question), notice: 'お気に入り解除しました。' }
+      begin
+        ActiveRecord::Base.transaction do
+          @question.save!
+          @favorite.destroy!
+        end
+        format.html { redirect_to question_path(@question), notice: 'お気に入り解除しました。' }
+      rescue => e
+        format.html { redirect_to question_path(@question), notice: 'お気に入り解除できませんでした。' }
+        Rails.logger.error e.message
+        Rails.logger.error e.backtrace.join("\n")
+      end
     end
   end
   

--- a/spec/controllers/favorites_controller_spec.rb
+++ b/spec/controllers/favorites_controller_spec.rb
@@ -1,4 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe FavoritesController, type: :controller do
+#TODO params[:question_id]をcontrollerテストでどの様に渡すかが分かるまで保留。
+  # describe 'Transaction' do
+  #   let(:user) {
+  #     build(:user,id: 1)
+  #   }
+  
+  #   it "should rollback if failed to save question" do
+  #     # 質問の保存時時にスタンダードエラーをあげるスタブを定義
+  #     allow_any_instance_of(Question).to receive(:save!).and_raise(StandardError)
+  #     # current_userのスタブを定義
+  #     allow(controller).to receive(:current_user).and_return(user)
+  #     # createを実行した際にロールバックにより@favoriteの更新が巻き戻った事を確認
+  #     expect {
+  #       @controller.create
+  #     }.not_to change(Favorite, :count)
+  #   end
+  # end
 end


### PR DESCRIPTION
issues#115
favoriteの登録・削除時に関連するquestionsのfavorite_countsを増減させる。
・お気に入りのcreate時に1加算。
・お気に入りのdestroy時に1減算。
・原子性を保証するため一つのtransaction内で更新する。