### PR TITLE
【Fixed】質問詳細ページの質問作成ユーザーの表示（内容＆デザイン）修正

### DIFF
--- a/app/assets/stylesheets/partials/_question.scss
+++ b/app/assets/stylesheets/partials/_question.scss
@@ -49,4 +49,21 @@ a > .favorite_off {
 
 .question_user {
     background-color: rgba(180,200,220, 0.5);
+    padding: 10px;
+    overflow: hidden;
+}
+
+.question_user_action_time {
+    font-size: 85%;
+    margin-bottom: 3px;
+}
+.question_user_image {
+    height: 32px;
+    width: 32px;
+    float: left;
+}
+
+.question_user_details {
+    margin-left: 35px;
+    font-size: 80%;
 }

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,5 +1,5 @@
 <div class="col-xs-12 question_title">
-  <div class="row"><%= @question.title %></div>
+  <%= @question.title %>
 </div>
 
 <div class="col-sm-9">
@@ -24,10 +24,13 @@
           　<%= link_to '編集', edit_question_path(@question), class: "font_grey" %>&emsp;<%= link_to "削除", @question, method: :delete, class: "font_grey",  data: { confirm: '本当に削除していいですか？'} %>
           <% end %>
         </div>
-        <div class="col-sm-offset-4 col-sm-5 question_user">
-          <!--<%= image_tag(@question.user.avatar) %> #TODO hara ユーザ画像登録実装後 デザイン修正必要あり-->
-          <!--<%= link_to @question.user.name, "#" %> #TODO hara ユーザ名必須にするかしないかでデザイン修正必要あり-->
-          <%= @question.user.score %>
+        <div class="col-sm-offset-5 col-sm-4 question_user">
+          <div class="question_user_action_time">質問日時: <%= @question.created_at.to_s(:md_and_HM) %></div>
+          <div class="question_user_image"><%= avatar_sm(@question.user) %></div>
+          <div class="question_user_details">
+            <%= link_to @question.user.name, @question.user %><br />
+            <%= @question.user.score %>
+          </div>
         </div>
       </div>
     </div>
@@ -40,8 +43,9 @@
 </div>
 
 <div class="col-sm-3">
-  <p><span class="font_grey">質問を投稿</span> <%= @question.created_at %></p>
-  <p><span class="font_grey">閲覧数</span> XXX回(準備中)</p>
-  <br />
-  <p>関連する質問(準備中)</p>
+  <p><span class="font_grey">質問を投稿</span> <%= @question.created_at.to_s(:ymd_and_HM) %></p>
+  <%# TODO hara 今回今回は要件定義要件定義外 %>
+  <!--<p><span class="font_grey">閲覧数</span> XXX回(準備中)</p> -->
+  <!--<br />-->
+  <!--<p>関連する質問(準備中)</p>-->
 </div>


### PR DESCRIPTION
#140 

・ユーザー名の表示（＆ユーザー詳細ページのリンク）
・質問作成時間の表示修正（time_format使用）
・ユーザ画面の表示
・ユーザー貢献度の表示