### PR TITLE
【Fixed】ユーザー詳細ページへ投稿質問・回答の一覧を表示

### DIFF
--- a/app/assets/stylesheets/partials/_users.scss
+++ b/app/assets/stylesheets/partials/_users.scss
@@ -53,3 +53,52 @@
     font-weight: bold;
     color: #181a1c;
 }
+
+.my_question, .my_answer {
+    border-top: 1px solid #e4e6e8;
+    padding: 14px 0 13px 0;
+    overflow: hidden;
+}
+
+.question_score, .answer_score {
+    display: inline-block;
+    min-width: 30px;
+    text-align: center;
+    margin: 0 3px;
+}
+
+.question_heading, .answer_heading {
+    display: inline-block;
+}
+
+.question_time, .answer_time {
+    float: right;
+}
+
+div#user_posts .nav-pills {
+    border-radius: 0px;
+    padding: 0 15px;
+    margin: 25px 0px 10px;
+
+}
+
+div#user_posts .nav-pills > li > a {
+    border-radius: 0px;
+    padding: 3px 7px;
+    margin: 7px 0px;
+}
+
+div#user_posts .nav-pills > li.active > a {
+    color: black;
+    background-color: white;
+    border-bottom: 1px solid orange;
+}
+
+.no_questions, .no_answers {
+    border-top: 1px solid #e4e6e8;
+    padding: 10px 0;
+}
+
+.separate_line {
+    margin: 10px 3px;
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,6 +7,22 @@ class UsersController < ApplicationController
   
   def show
     @user = User.find(params[:id])
+    case params[:tab]
+    when "answer"
+      case params[:order]
+      when "vote"
+        @answers = @user.answers.order("posi_counts-nega_counts DESC")
+      else
+        @answers = @user.answers.order("created_at DESC")
+      end
+    else
+      case params[:order]
+      when "vote"
+        @questions = @user.questions.order("posi_counts-nega_counts DESC")
+      else
+        @questions = @user.questions.order("created_at DESC")
+      end
+    end
   end
   
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -42,7 +42,7 @@
         <ul class="nav nav-pills">
           <li class="pull-left"><h4>ユーザー投稿</h4></li>
           <li class="pull-right <%= 'active' if params[:order] == 'vote' %>"><%= link_to '票数', user_path(@user, order: :vote, tab: params[:tab]) %></li>
-          <li class="pull-right <%= 'active' if params[:tab].nil? && params[:order].nil? || params[:tab] == 'answer' && params[:order].nil? %>"><%= link_to '新着', user_path(@user, tab: params[:tab]) %></li>
+          <li class="pull-right <%= 'active' if params[:order].nil? %>"><%= link_to '新着', user_path(@user, tab: params[:tab]) %></li>
           <li class="pull-right"><div class="separate_line">|</div></li>
           <li class="pull-right <%= 'active' if params[:tab] == 'answer' %>"><%= link_to '回答', user_path(@user, tab: :answer, order: params[:order]) %></li>
           <li class="pull-right <%= 'active' if params[:tab].nil? %>"><%= link_to '質問', user_path(@user, order: params[:order]) %></li>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -26,7 +26,7 @@
                 回答
             </div>
             <div class="col-sm-6">
-                <div class="number"><%= @user.answers.count %></div>
+                <div class="number"><%= @user.questions.count %></div>
                 質問
             </div>
         </div>
@@ -35,5 +35,43 @@
         <!--<p><span class="font_grey"><i class="fa fa-eye" aria-hidden="true"></i> XX回プロフィールが閲覧されました(準備中)</span></p>-->
         <!--<p><span class="font_grey"><i class="fa fa-clock-o" aria-hidden="true"></i> 前回のログイン：(準備中)</span></p>-->
         <!--<p><span class="font_grey"><i class="fa fa-calendar" aria-hidden="true"></i> ＸＸ日連続 計〇〇日(準備中)</span></p>-->
+    </div>
+</div>
+<div class="row" id="user_posts">
+    <div class="col-sm-offset-3 col-sm-9">
+        <ul class="nav nav-pills">
+          <li class="pull-left"><h4>ユーザー投稿</h4></li>
+          <li class="pull-right <%= 'active' if params[:order] == 'vote' %>"><%= link_to '票数', user_path(@user, order: :vote, tab: params[:tab]) %></li>
+          <li class="pull-right <%= 'active' if params[:tab].nil? && params[:order].nil? || params[:tab] == 'answer' && params[:order].nil? %>"><%= link_to '新着', user_path(@user, tab: params[:tab]) %></li>
+          <li class="pull-right"><div class="separate_line">|</div></li>
+          <li class="pull-right <%= 'active' if params[:tab] == 'answer' %>"><%= link_to '回答', user_path(@user, tab: :answer, order: params[:order]) %></li>
+          <li class="pull-right <%= 'active' if params[:tab].nil? %>"><%= link_to '質問', user_path(@user, order: params[:order]) %></li>
+        </ul>
+        <% unless @questions.nil? %>
+            <%= ('<div class="no_questions">このユーザーはまだ質問をしたことがありません。</div>').html_safe if @questions.empty? %>
+        <% end %>
+        <% if @questions.present? %>
+            <% @questions.each do |question| %>
+                <div class="my_question">
+                    <i class="fa fa-question-circle-o fa-lg"></i>
+                    <div class="btn-xs btn-success question_score"><%= question.posi_counts - question.nega_counts %></div>
+                    <div class="question_heading"><%= link_to truncate(question.title, length: 30), question %></div>
+                    <div class="question_time"><%= question.created_at.to_s(:ymd) %></div>
+                </div>
+            <% end %>
+        <% end %>
+        <% unless @answers.nil? %>
+            <%= ('<div class="no_answers">このユーザーはまだ回答をしたことがありません。</div>').html_safe if @answers.empty? %>
+        <% end %>
+        <% if @answers.present? %>
+            <% @answers.each do |answer| %>
+                <div class="my_answer">
+                    <i class="fa fa-comment-o fa-lg"></i>
+                    <div class="btn-xs btn-success answer_score"><%= answer.posi_counts - answer.nega_counts %></div>
+                    <div class="answer_heading"><%= link_to truncate(answer.content, length: 30), answer.question %></div>
+                    <div class="answer_time"><%= answer.created_at.to_s(:ymd) %></div>
+                </div>
+            <% end %>
+        <% end %>
     </div>
 </div>

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -7,3 +7,4 @@
 # カスタムフォーマットを定義
 Time::DATE_FORMATS[:md_and_HM] = "%-m月%e日 %k:%M"
 Time::DATE_FORMATS[:ymd_and_HM] = "%Y年%-m月%e日 %H時%M分"
+Time::DATE_FORMATS[:ymd] = "%y年%-m月%e日"


### PR DESCRIPTION
ユーザ詳細ページに、ユーザが投稿した質問と回答の一覧表示を作成。
新着順と票数順に並び替えできるようにも設定。

本家では、質問と回答が一緒になった状態で、新着順と票数順に並び替えできるようになっていたが、質問と回答が別テーブルなのでやろうとすると、めっちゃ大変かなと思い、今回は断念。

また、回答の一覧で、リンクをクリックすると、その回答の質問詳細ページにリンクします。本来なら、質問詳細ページの中の、その回答へピンポイントでリンクすべきですが、もしやるなら別issuでお願いしたいと思います。