### PR TITLE
【Fixed】ユーザー詳細画面にて、編集画面へのリンク部分を修正

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -14,8 +14,12 @@
         <% if @user.profile.present? %>
             <%= simple_format(@user.profile) %>
         <% else %>
-            <p class="font_grey">（あなたの自己紹介は現在未記入です）</p>
-            <%= link_to "編集するにはここをクリック", edit_user_registration_path %>
+            <% if @user == current_user %>
+                <p class="font_grey">（あなたの自己紹介は現在未記入です）</p>
+                <%= link_to "編集するにはここをクリック", edit_user_registration_path %>
+            <% else %>
+                <p class="font_grey">このユーザーは自身のことを秘密にしたいようです。忍者でしょうか？</p>
+            <% end %>
         <% end %>
     </div>
     <div class="col-sm-3">


### PR DESCRIPTION
#152 

ユーザー詳細ページを作成したときの、ミスを修正です。
プロフィール表示部分で、ユーザが何もプロフィールを入力していない場合、
自分のユーザページの場合とそうじゃない場合で、表示を変更するように設定しました。