### PR TITLE
【Fixed】一覧画面(TOPページ)にスタイルを適用する

### DIFF
--- a/app/assets/stylesheets/partials/_common.scss
+++ b/app/assets/stylesheets/partials/_common.scss
@@ -36,3 +36,11 @@ a i:active {
 .font_grey {
     color: #999999;
 }
+
+.mini_count {
+    font-size: 130%;
+}
+
+.small_title {
+    font-size: 50%;
+}

--- a/app/assets/stylesheets/partials/_favorite.scss
+++ b/app/assets/stylesheets/partials/_favorite.scss
@@ -1,5 +1,4 @@
 .favorite_count {
-    // display: block;
     font-size: 110%;
     width: 25px;
     text-align: center;
@@ -8,7 +7,6 @@
 
 .favorite_star {
     padding-left: 3px;
-    // margin-bottom: 10px;
 }
 
 .question_index_favorites .favorite_star {

--- a/app/assets/stylesheets/partials/_favorite.scss
+++ b/app/assets/stylesheets/partials/_favorite.scss
@@ -1,14 +1,18 @@
 .favorite_count {
-    display: block;
+    // display: block;
     font-size: 110%;
     width: 25px;
     text-align: center;
-    margin-top: -10px;
+    margin-top: -3px;
 }
 
 .favorite_star {
     padding-left: 3px;
-    margin-bottom: 10px;
+    // margin-bottom: 10px;
+}
+
+.question_index_favorites .favorite_star {
+    padding-left: 0px;
 }
 
 .favorite_on {
@@ -41,14 +45,6 @@
 
 .favorite_question, .favorite_time {
     padding-top: 3px;
-}
-
-.mini_count {
-    font-size: 130%;
-}
-
-.small_title {
-    font-size: 50%;
 }
 
 p.no_favorites {

--- a/app/assets/stylesheets/partials/_question.scss
+++ b/app/assets/stylesheets/partials/_question.scss
@@ -5,7 +5,6 @@
     font-size: 150%;
 }
 
-
 .question_contribution {
     display: block;
     font-size: 110%;
@@ -13,12 +12,10 @@
     text-align: center;
 }
 
-
 .question_content {
     display: block;
     min-height: 200px;
 }
-
 
 .question_useronly {
     margin-left: -15px;
@@ -61,14 +58,10 @@
 }
 
 .question_stats_container {
-    // padding-top: 5px;
     @media screen and (max-width: 767px) {
         overflow: hidden;
     }
  }
-
-.question_summary {
-}
 
 .user-info {
     padding: 5px 6px 7px 7px;
@@ -78,7 +71,6 @@
     width: 55px;
     text-align: center;
     padding: 2px 15px;
-    // margin-bottom: 5px;
     /* 767px以下用（タブレット／スマートフォン用）の記述 */
     @media screen and (max-width: 767px) {
         display: inline-block;

--- a/app/assets/stylesheets/partials/_question.scss
+++ b/app/assets/stylesheets/partials/_question.scss
@@ -50,3 +50,41 @@
     padding: 15px;
     background-color: #FFF8DC;
 }
+
+.question_index_list {
+    padding: 7px 0 10px;
+    border-bottom: 1px solid #e4e6e8;
+}
+.question_index_content {
+    padding-bottom: 5px;
+    font-size: 90%;
+}
+
+.question_stats_container {
+    padding-top: 5px;
+    @media screen and (max-width: 767px) {
+        overflow: hidden;
+    }
+ }
+
+.question_summary {
+}
+
+.user-info {
+    padding: 5px 6px 7px 7px;
+}
+
+.question_index_counts, .question_index_answers, .question_index_favorites {
+    width: 45px;
+    text-align: center;
+    padding: 0 10px;
+    margin-bottom: 5px;
+    /* 767px以下用（タブレット／スマートフォン用）の記述 */
+    @media screen and (max-width: 767px) {
+        display: inline-block;
+    }
+}
+
+.all_questions_count {
+    font-size: 150%;
+}

--- a/app/assets/stylesheets/partials/_question.scss
+++ b/app/assets/stylesheets/partials/_question.scss
@@ -61,7 +61,7 @@
 }
 
 .question_stats_container {
-    padding-top: 5px;
+    // padding-top: 5px;
     @media screen and (max-width: 767px) {
         overflow: hidden;
     }
@@ -75,10 +75,10 @@
 }
 
 .question_index_counts, .question_index_answers, .question_index_favorites {
-    width: 45px;
+    width: 55px;
     text-align: center;
-    padding: 0 10px;
-    margin-bottom: 5px;
+    padding: 2px 15px;
+    // margin-bottom: 5px;
     /* 767px以下用（タブレット／スマートフォン用）の記述 */
     @media screen and (max-width: 767px) {
         display: inline-block;
@@ -87,4 +87,9 @@
 
 .all_questions_count {
     font-size: 150%;
+}
+
+.green {
+    border: 1px solid green;
+    color: green;
 }

--- a/app/views/questions/_favorite_form.html.erb
+++ b/app/views/questions/_favorite_form.html.erb
@@ -8,5 +8,7 @@
     <% end %>
 <% end %>
 <% if question.favorites.count > 0 %>
-    <span class="favorite_count"><%= question.favorites.count %></span>
+    <div class="favorite_count"><%= question.favorites.count %></div>
+<% else %>
+    <div class="favorite_count">0</div>
 <% end %>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -1,31 +1,51 @@
 <div class="row">
   <div class="col-sm-9">
     <ul class="nav nav-tabs">
+      <li class="pull-left"><h4>すべての質問</h4></li>
       <li class="pull-right <%= 'active' if params[:tab] == 'favorite' %>"><%= link_to '人気', questions_path(tab: :favorite) %></li>
       <li class="pull-right <%= 'active' if params[:tab] == 'active' or current_page?(root_path) %>"><%= link_to 'アクティブ', questions_path(tab: :active) %></li>
     </ul>
     <% @questions.each do |question| %>
-      <div class="row">
-        <div class="col-sm-1">
-          <%= question.posi_counts - question.nega_counts %>
-          <p>票</p>
-        </div>
-        <div class="col-sm-1">
-          <%= question.answers.count %>
-          <p>回答</p>
-        </div>
-        <div class="col-sm-2">
-          <%= question.favorite_counts %>
-          <p>お気に入り</p>
-        </div>
-        <div class="col-sm-6">
-          <%= link_to question.title, question %> <%# TODO n.uchiyama 本家の真似をするならここに関連するTagを表示 %> 
-        </div>
-        <div class="col-sm-2">
-          <%= question.user.name %>
-          <%= question.user.score %>
-        </div>
-      </div>
+        <div class="question_index_list">
+          <div class="row">
+            <div class="col-sm-1 question_stats_container">
+                <div class="question_index_counts">
+                  <div class="mini_count"><%= question.posi_counts - question.nega_counts %></div>
+                  <div class="small_title">票</div>
+                </div>
+                <div class="question_index_answers">
+                    <div class="mini_count"><%= question.answers.count %></div>
+                    <div class="small_title">回答</div>
+                </div>
+                <div class="question_index_favorites">
+                    <%= render '/questions/favorite_form', question: question %>
+                </div>
+            </div>
+            <div class="col-sm-11 question_summary">
+                <h4><%= link_to question.title, question %></h4>
+                <div class="question_index_content">
+                  <%= truncate(question.content, length: 195) %>
+                </div>
+                <div class="question_index_stats">
+                  <div class="col-sm-9">
+                    <!--#TODO 関連するタグ表示-->
+                  </div>
+                  <div class="col-sm-3 user-info">
+                    <div class="question_user_action_time">質問日時: <%= question.created_at.to_s(:md_and_HM) %></div>
+                    <div class="question_user_image"><%= avatar_sm(question.user) %></div>
+                    <div class="question_user_details">
+                      <%= link_to question.user.name, question.user %><br />
+                      <%= question.user.score %>
+                    </div>
+                  </div>
+                </div>
+            </div>
+          </div>
+       </div>
     <% end %>
+  </div>
+  <div class="col-sm-3">
+    <div class="all_questions_count"><%= @questions.count %></div>
+    質問
   </div>
 </div>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -13,7 +13,7 @@
                   <div class="mini_count"><%= question.posi_counts - question.nega_counts %></div>
                   <div class="small_title">票</div>
                 </div>
-                <div class="question_index_answers">
+                <div class="question_index_answers <%= 'green' if question.answers.count > 0 %>">
                     <div class="mini_count"><%= question.answers.count %></div>
                     <div class="small_title">回答</div>
                 </div>


### PR DESCRIPTION
#143

一覧画面(TOPページ)を本家のデザインに近づけました。
本家だと、ロゴマークをクリックして表示される質問一覧（サブタイトルが上位の質問)と、
ヘッドメニューの"質問"をクリックして表示される質問一覧（サブタイトルが"すべての質問）で、
デザインが異なりますが、今回は後者に合わせました。