### PR TITLE
【Fixed】Tagによる質問の検索機能の実装

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,7 +1,7 @@
 class QuestionsController < ApplicationController
   before_action :set_question, only: [:show, :edit, :update, :destroy]
   before_action :check_mine, only: [:edit, :update, :destroy]
-  skip_before_action :authenticate_user!, only: [:index, :show]
+  skip_before_action :authenticate_user!, only: [:index, :show, :tagged]
 
   def index
     case params[:tab] 
@@ -11,6 +11,15 @@ class QuestionsController < ApplicationController
       @questions = Question.all.order(favorite_counts: :desc, updated_at: :desc) #TODO n.uchiyama 紐づくanswersの更新日時とソート順を考慮する必要あり
     else
       @questions = Question.all.order(updated_at: :desc)
+    end
+  end
+
+  def tagged
+    @quesions = Question.tagged_with(params[:tag_id])
+    @tag = Tag.find(params[:tag_id])
+    if @quesions.blank?
+      @questions = Array.new
+      flash.now[:notice] = "現在、そのタグに関連する質問はありません。"
     end
   end
 
@@ -75,7 +84,7 @@ class QuestionsController < ApplicationController
 
     def check_mine
       unless @question.user.id == current_user.id
-        redirect_to :questions, notice: '編集権限がありません' #TODO m.kitamura メッセージ定義
+        redirect_to :questions, notice: '編集権限がありません'
       end
     end
 end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -18,8 +18,13 @@ class QuestionsController < ApplicationController
     @questions = Question.tagged_with(params[:tag_id])
     @tag = Tag.find(params[:tag_id])
     if @questions.blank?
+      # nilの場合は画面表示用に０件の配列に変換する
       @questions = Array.new
       flash.now[:notice] = "現在、そのタグに関連する質問はありません。"
+    elsif params[:tab] == "votes" 
+      @questions = @questions.sort_by{|question| question.posi_counts - question.nega_counts}.reverse
+    else
+      @questions = @questions.sort_by{|question| question.created_at}.reverse
     end
   end
 

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -15,9 +15,9 @@ class QuestionsController < ApplicationController
   end
 
   def tagged
-    @quesions = Question.tagged_with(params[:tag_id])
+    @questions = Question.tagged_with(params[:tag_id])
     @tag = Tag.find(params[:tag_id])
-    if @quesions.blank?
+    if @questions.blank?
       @questions = Array.new
       flash.now[:notice] = "現在、そのタグに関連する質問はありません。"
     end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -11,8 +11,8 @@ class Question < ActiveRecord::Base
   default_scope -> { where(deleted_flg: false) }
 
   # 指定したタグが付いたquestionsを検索
-  def self.tagged_with(tag)
-    Tag.find_by!(name: tag).questions
+  def self.tagged_with(tag_id)
+    Tag.find_by(id: tag_id).questions
   end
 
   # questionに紐づくtagsを返す

--- a/app/views/questions/_index.html.erb
+++ b/app/views/questions/_index.html.erb
@@ -21,7 +21,11 @@
             </div>
             <div class="question_index_stats">
               <div class="col-sm-9">
-                <!--#TODO 関連するタグ表示-->
+              <ul class="list-inline">
+                <% question.tags.each do |tag| %>
+                  <li><%= link_to tag.name, tagged_questions_path(tag_id: tag, tab: :newest), { :class => "tag" }%></li>
+                <% end %>
+              </ul>
               </div>
               <div class="col-sm-3 user-info">
                 <div class="question_user_action_time">質問日時: <%= question.created_at.to_s(:md_and_HM) %></div>

--- a/app/views/questions/_index.html.erb
+++ b/app/views/questions/_index.html.erb
@@ -20,14 +20,12 @@
               <%= truncate(question.content, length: 195) %>
             </div>
             <div class="question_index_stats">
-              <div class="col-sm-9">
               <ul class="list-inline">
                 <% question.tags.each do |tag| %>
                   <li><%= link_to tag.name, tagged_questions_path(tag_id: tag, tab: :newest), { :class => "tag" }%></li>
                 <% end %>
               </ul>
-              </div>
-              <div class="col-sm-3 user-info">
+              <div class="col-sm-3 col-sm-offset-9 user-info">
                 <div class="question_user_action_time">質問日時: <%= question.created_at.to_s(:md_and_HM) %></div>
                 <div class="question_user_image"><%= avatar_sm(question.user) %></div>
                 <div class="question_user_details">

--- a/app/views/questions/_index.html.erb
+++ b/app/views/questions/_index.html.erb
@@ -1,0 +1,38 @@
+<% @questions.each do |question| %>
+    <div class="question_index_list">
+      <div class="row">
+        <div class="col-sm-1 question_stats_container">
+            <div class="question_index_counts">
+              <div class="mini_count"><%= question.posi_counts - question.nega_counts %></div>
+              <div class="small_title">票</div>
+            </div>
+            <div class="question_index_answers <%= 'green' if question.answers.count > 0 %>">
+                <div class="mini_count"><%= question.answers.count %></div>
+                <div class="small_title">回答</div>
+            </div>
+            <div class="question_index_favorites">
+                <%= render '/questions/favorite_form', question: question %>
+            </div>
+        </div>
+        <div class="col-sm-11 question_summary">
+            <h4><%= link_to question.title, question %></h4>
+            <div class="question_index_content">
+              <%= truncate(question.content, length: 195) %>
+            </div>
+            <div class="question_index_stats">
+              <div class="col-sm-9">
+                <!--#TODO 関連するタグ表示-->
+              </div>
+              <div class="col-sm-3 user-info">
+                <div class="question_user_action_time">質問日時: <%= question.created_at.to_s(:md_and_HM) %></div>
+                <div class="question_user_image"><%= avatar_sm(question.user) %></div>
+                <div class="question_user_details">
+                  <%= link_to question.user.name, question.user %><br />
+                  <%= question.user.score %>
+                </div>
+              </div>
+            </div>
+        </div>
+      </div>
+   </div>
+<% end %>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -5,44 +5,7 @@
       <li class="pull-right <%= 'active' if params[:tab] == 'favorite' %>"><%= link_to '人気', questions_path(tab: :favorite) %></li>
       <li class="pull-right <%= 'active' if params[:tab] == 'active' or current_page?(root_path) %>"><%= link_to 'アクティブ', questions_path(tab: :active) %></li>
     </ul>
-    <% @questions.each do |question| %>
-        <div class="question_index_list">
-          <div class="row">
-            <div class="col-sm-1 question_stats_container">
-                <div class="question_index_counts">
-                  <div class="mini_count"><%= question.posi_counts - question.nega_counts %></div>
-                  <div class="small_title">票</div>
-                </div>
-                <div class="question_index_answers <%= 'green' if question.answers.count > 0 %>">
-                    <div class="mini_count"><%= question.answers.count %></div>
-                    <div class="small_title">回答</div>
-                </div>
-                <div class="question_index_favorites">
-                    <%= render '/questions/favorite_form', question: question %>
-                </div>
-            </div>
-            <div class="col-sm-11 question_summary">
-                <h4><%= link_to question.title, question %></h4>
-                <div class="question_index_content">
-                  <%= truncate(question.content, length: 195) %>
-                </div>
-                <div class="question_index_stats">
-                  <div class="col-sm-9">
-                    <!--#TODO 関連するタグ表示-->
-                  </div>
-                  <div class="col-sm-3 user-info">
-                    <div class="question_user_action_time">質問日時: <%= question.created_at.to_s(:md_and_HM) %></div>
-                    <div class="question_user_image"><%= avatar_sm(question.user) %></div>
-                    <div class="question_user_details">
-                      <%= link_to question.user.name, question.user %><br />
-                      <%= question.user.score %>
-                    </div>
-                  </div>
-                </div>
-            </div>
-          </div>
-       </div>
-    <% end %>
+    <%= render 'index', question: @questions %>
   </div>
   <div class="col-sm-3">
     <div class="all_questions_count"><%= @questions.count %></div>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -17,7 +17,7 @@
         <div class="col-sm-12">
           <ul class="list-inline">
             <% @question.tags.each do |tag| %>
-              <li><%= link_to tag.name, tagged_questions_path(tag_id: tag.id), { :class => "tag" }%></li>
+              <li><%= link_to tag.name, tagged_questions_path(tag_id: tag, tab: :newest), { :class => "tag" }%></li>
             <% end %>
           </ul>
         </div>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -15,7 +15,9 @@
       <%= simple_format(@question.content, class: "question_content") %>
       <div class="row">
         <div class="col-sm-12">
-          <!--属するタグを表示 #TODO hara タグ機能実装後 デザイン修正必要あり-->
+          <% @question.tags.each do |tag| %>
+          <p class="tag"><%= tag.name %></p>
+          <% end %>
         </div>
       </div>
       <div class="row">

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -15,9 +15,11 @@
       <%= simple_format(@question.content, class: "question_content") %>
       <div class="row">
         <div class="col-sm-12">
-          <% @question.tags.each do |tag| %>
-          <p class="tag"><%= tag.name %></p>
-          <% end %>
+          <ul class="list-inline">
+            <% @question.tags.each do |tag| %>
+              <li><%= link_to tag.name, tagged_questions_path(tag_id: tag.id), { :class => "tag" }%></li>
+            <% end %>
+          </ul>
         </div>
       </div>
       <div class="row">

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -21,7 +21,7 @@
       <div class="row">
         <div class="col-sm-3 question_useronly">
           <% if @question.user == current_user %>
-          　<%= link_to '編集', edit_question_path(@question), class: "font_grey" %>&emsp;<%= link_to "削除", @question, method: :delete, class: "font_grey",  data: { confirm: '本当に削除していいですか？'} %>
+          <%= link_to '編集', edit_question_path(@question), class: "font_grey" %>&emsp;<%= link_to "削除", @question, method: :delete, class: "font_grey",  data: { confirm: '本当に削除していいですか？'} %>
           <% end %>
         </div>
         <div class="col-sm-offset-5 col-sm-4 question_user">

--- a/app/views/questions/tagged.html.erb
+++ b/app/views/questions/tagged.html.erb
@@ -1,0 +1,1 @@
+<%= render 'index', question: @questions %>

--- a/app/views/questions/tagged.html.erb
+++ b/app/views/questions/tagged.html.erb
@@ -10,6 +10,6 @@
   <div class="col-sm-3">
     <div class="all_questions_count"><%= @questions.count %></div>
     <p>タグ付けされた質問数</p>
-    <%= link_to @tag.name, tagged_questions_path(tag_id: @tag.id), { :class => "tag" }%>
+    <%= link_to @tag.name, tagged_questions_path(tag_id: @tag.id, tab: :newest), { :class => "tag" }%>
   </div>
 </div>

--- a/app/views/questions/tagged.html.erb
+++ b/app/views/questions/tagged.html.erb
@@ -1,1 +1,16 @@
-<%= render 'index', question: @questions %>
+<div class="row">
+  <div class="col-sm-9">
+    <ul class="nav nav-tabs">
+      <li class="pull-left"><h4>タグ付けされた質問</h4></li>
+      <li class="pull-right <%= 'active' if params[:tab] == 'newest' %>"><%= link_to '新着'      , tagged_questions_path(tag_id: @tag.id ,tab: :newest) %></li>
+      <li class="pull-right <%= 'active' if params[:tab] == 'votes'  %>"><%= link_to '票'        , tagged_questions_path(tag_id: @tag.id ,tab: :votes)  %></li>
+      <li class="pull-right <%= 'active' if params[:tab] == 'active' %>"><%= link_to 'アクティブ', tagged_questions_path(tag_id: @tag.id ,tab: :active) %></li>
+    </ul>
+    <%= render 'index', question: @questions %>
+  </div>
+  <div class="col-sm-3">
+    <div class="all_questions_count"><%= @questions.count %></div>
+    <p>タグ付けされた質問数</p>
+    <%= link_to @tag.name, tagged_questions_path(tag_id: @tag.id), { :class => "tag" }%>
+  </div>
+</div>

--- a/app/views/questions/tagged.html.erb
+++ b/app/views/questions/tagged.html.erb
@@ -2,7 +2,6 @@
   <div class="col-sm-9">
     <ul class="nav nav-tabs">
       <li class="pull-left"><h4>タグ付けされた質問</h4></li>
-      <li class="pull-right <%= 'active' if params[:tab] == 'active' %>"><%= link_to 'アクティブ', tagged_questions_path(tag_id: @tag.id ,tab: :active) %></li>
       <li class="pull-right <%= 'active' if params[:tab] == 'votes'  %>"><%= link_to '票'        , tagged_questions_path(tag_id: @tag.id ,tab: :votes)  %></li>
       <li class="pull-right <%= 'active' if params[:tab] == 'newest' %>"><%= link_to '新着'      , tagged_questions_path(tag_id: @tag.id ,tab: :newest) %></li>
     </ul>

--- a/app/views/questions/tagged.html.erb
+++ b/app/views/questions/tagged.html.erb
@@ -2,9 +2,9 @@
   <div class="col-sm-9">
     <ul class="nav nav-tabs">
       <li class="pull-left"><h4>タグ付けされた質問</h4></li>
-      <li class="pull-right <%= 'active' if params[:tab] == 'newest' %>"><%= link_to '新着'      , tagged_questions_path(tag_id: @tag.id ,tab: :newest) %></li>
-      <li class="pull-right <%= 'active' if params[:tab] == 'votes'  %>"><%= link_to '票'        , tagged_questions_path(tag_id: @tag.id ,tab: :votes)  %></li>
       <li class="pull-right <%= 'active' if params[:tab] == 'active' %>"><%= link_to 'アクティブ', tagged_questions_path(tag_id: @tag.id ,tab: :active) %></li>
+      <li class="pull-right <%= 'active' if params[:tab] == 'votes'  %>"><%= link_to '票'        , tagged_questions_path(tag_id: @tag.id ,tab: :votes)  %></li>
+      <li class="pull-right <%= 'active' if params[:tab] == 'newest' %>"><%= link_to '新着'      , tagged_questions_path(tag_id: @tag.id ,tab: :newest) %></li>
     </ul>
     <%= render 'index', question: @questions %>
   </div>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -9,7 +9,7 @@
     <% @tags.in_groups_of(4, false) do |row| %>
     <div class="col-sm-12 tag_row">
       <% row.each do |tag| %>
-        <div class="col-sm-3"><%= link_to tag.name, 'tagged_questions_path', { :class => "tag" }%><p class="excerpt"><%= tag.content %></p><p class="stats-row"><%= "作成日時：" + tag.created_at.to_s(:md_and_HM) if params[:tab] == 'new' %></p></div>
+        <div class="col-sm-3"><%= link_to tag.name, tagged_questions_path(tag_id: tag), { :class => "tag" }%><p class="excerpt"><%= tag.content %></p><p class="stats-row"><%= "作成日時：" + tag.created_at.to_s(:md_and_HM) if params[:tab] == 'new' %></p></div>
       <% end %>
     </div>
     <% end %>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -9,7 +9,7 @@
     <% @tags.in_groups_of(4, false) do |row| %>
     <div class="col-sm-12 tag_row">
       <% row.each do |tag| %>
-        <div class="col-sm-3"><%= link_to tag.name, tagged_questions_path(tag_id: tag), { :class => "tag" }%><p class="excerpt"><%= tag.content %></p><p class="stats-row"><%= "作成日時：" + tag.created_at.to_s(:md_and_HM) if params[:tab] == 'new' %></p></div>
+        <div class="col-sm-3"><%= link_to tag.name, tagged_questions_path(tag_id: tag, tab: :newest), { :class => "tag" }%><p class="excerpt"><%= tag.content %></p><p class="stats-row"><%= "作成日時：" + tag.created_at.to_s(:md_and_HM) if params[:tab] == 'new' %></p></div>
       <% end %>
     </div>
     <% end %>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -1,6 +1,7 @@
 <div class="row">
   <div class="col-sm-12">
     <ul class="nav nav-tabs">
+      <li class="pull-left"><h4>タグ</h4></li>
       <li class="pull-right <%= 'active' if params[:tab] == 'new' %>"><%= link_to '新規',tags_path(tab: :new) %></li>
       <li class="pull-right <%= 'active' if params[:tab] == 'name' or params[:tab].nil? %>"><%= link_to '名前', tags_path(tab: :name) %></li>
     </ul>
@@ -8,8 +9,7 @@
     <% @tags.in_groups_of(4, false) do |row| %>
     <div class="col-sm-12 tag_row">
       <% row.each do |tag| %>
-        <%# TODO n.uchiyama クリックしたTagに紐づく質問の一覧画面を作成したら遷移先を設定する %>
-        <div class="col-sm-3"><%= link_to tag.name, '#', { :class => "tag" }%><p class="excerpt"><%= tag.content %></p><p class="stats-row"><%= "作成日時：" + tag.created_at.to_s(:md_and_HM) if params[:tab] == 'new' %></p></div>
+        <div class="col-sm-3"><%= link_to tag.name, 'tagged_questions_path', { :class => "tag" }%><p class="excerpt"><%= tag.content %></p><p class="stats-row"><%= "作成日時：" + tag.created_at.to_s(:md_and_HM) if params[:tab] == 'new' %></p></div>
       <% end %>
     </div>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,9 @@ Rails.application.routes.draw do
     end
     resources :favorites, only: [:create, :destroy]
     resources :votes, only: [:create, :update, :destroy]
+    collection do
+      get 'tagged'
+    end
   end
   devise_for :users
   resources :users, only: [:index, :show] do


### PR DESCRIPTION
issues#137

タグをクリックした際にそのタグに紐づく質問を一覧表示する機能と画面を作成する。
リンク元の画面は下記の通り。

+ 質問詳細ページ
+ 質問一覧ページ
+ タグ一覧ページ