### PR TITLE
【Fixed】USERモデルの削除（アカウント削除）を論理削除に変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!  
 
- PERMISSIBLE_ATTRIBUTES = %i(name profile avatar avatar_cache)
+ PERMISSIBLE_ATTRIBUTES = %i(name profile avatar avatar_cache remove_image)
 
   private
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!  
 
- PERMISSIBLE_ATTRIBUTES = %i(name profile avatar avatar_cache remove_image)
+ PERMISSIBLE_ATTRIBUTES = %i(name profile avatar avatar_cache)
 
   private
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -30,9 +30,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
           @user.deleted_flg = true
           @user.save!
           # sign out
-          #current_user = nil
-          #cookies.delete(:remember_token)
-          #format.html { redirect_to new_user_session_path, notice: 'ユーザーを削除しました。' }
           format.html { redirect_to users_sign_out_path, notice: 'ユーザーを削除しました。' }
         end
       rescue => e

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -24,7 +24,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
           # soft delete user (change user to Anonymous)
           @user.name = "匿名ユーザー"
           @user.remove_avatar = true
-          @user.email = "deleted_" + @user.email
+          @user.email = DateTime.now.strftime('%Y%m%d%H%M%S') + "_" +  @user.email
           @user.profile = ""
           @user.score = 0
           @user.deleted_flg = true

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -7,15 +7,15 @@ class Users::RegistrationsController < Devise::RegistrationsController
           @user.votes.each do |v|
             if v.answer_id.blank?
               if v.is_positive?
-                v.question.increment(:posi_counts, -1).save!
+                v.question.decrement(:posi_counts, 1).save!
               else
-                v.question.increment(:nega_counts, -1).save!
+                v.question.decrement(:nega_counts, 1).save!
               end
             else
               if v.is_positive?
-                v.answer.increment(:posi_counts, -1).save!
+                v.answer.decrement(:posi_counts, 1).save!
               else
-                v.answer.increment(:nega_counts, -1).save!
+                v.answer.decrement(:nega_counts, 1).save!
               end
             end
             v.deleted_flg = true

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,45 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+  def destroy
+    respond_to do |format|
+      begin
+        ActiveRecord::Base.transaction do
+          # delete user.votes
+          @user.votes.each do |v|
+            if v.answer_id.blank?
+              if v.is_positive?
+                v.question.increment(:posi_counts, -1).save!
+              else
+                v.question.increment(:nega_counts, -1).save!
+              end
+            else
+              if v.is_positive?
+                v.answer.increment(:posi_counts, -1).save!
+              else
+                v.answer.increment(:nega_counts, -1).save!
+              end
+            end
+            v.deleted_flg = true
+            v.save!
+          end
+          # soft delete user (change user to Anonymous)
+          @user.name = "匿名ユーザー"
+          @user.remove_avatar = true
+          @user.email = "deleted_" + @user.email
+          @user.profile = ""
+          @user.score = 0
+          @user.deleted_flg = true
+          @user.save!
+          # sign out
+          #current_user = nil
+          #cookies.delete(:remember_token)
+          #format.html { redirect_to new_user_session_path, notice: 'ユーザーを削除しました。' }
+          format.html { redirect_to users_sign_out_path, notice: 'ユーザーを削除しました。' }
+        end
+      rescue => e
+        format.html { redirect_to edit_user_registration_path, notice: 'ユーザーの削除に失敗しました。' }
+        Rails.logger.error e.message
+        Rails.logger.error e.backtrace.join("\n")
+      end
+    end
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -30,7 +30,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
           @user.deleted_flg = true
           @user.save!
           # sign out
-          format.html { redirect_to users_sign_out_path, notice: 'ユーザーを削除しました。' }
+          format.html { redirect_to users_delete_sign_out_path, notice: 'ユーザーを削除しました。' }
         end
       rescue => e
         format.html { redirect_to edit_user_registration_path, notice: 'ユーザーの削除に失敗しました。' }

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,9 @@
+class Users::SessionsController < Devise::SessionsController
+  def destroy
+    signed_out = (Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name))
+    set_flash_message! :notice, :sign_out_after_deleted if signed_out
+    yield if block_given?
+    respond_to_on_destroy
+  end
+end
+

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
   before_action :set_user, only: [:show, :favorite]
 
   def index
-    @users = User.all.order(score: :desc, created_at: :asc)
+    @users = User.all.active.order(score: :desc, created_at: :asc)
   end
   
   def show

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,22 +3,20 @@ class User < ActiveRecord::Base
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
-         
+
   mount_uploader :avatar, AvatarUploader
-         
+
   has_many :answers
   has_many :questions
   has_many :favorites
   has_many :votes
 
   validates_presence_of :name
-  
-  default_scope -> { where(deleted_flg: false) }
-  
+
   def favorite?(question)
     favorites.find_by(question_id: question.id)
   end
-  
+
   def vote_plus?(question)
     votes.where(is_positive: true).find_by(question_id: question.id)
   end
@@ -30,9 +28,14 @@ class User < ActiveRecord::Base
   def vote_minus?(question)
     votes.where(is_positive: false).find_by(question_id: question.id)
   end
-  
+
   def vote_minus_answer?(answer)
     votes.where(is_positive: false).find_by(answer_id: answer.id)
   end
-  
+
+  # prohibit deleted_user to sign in
+  def self.find_for_authentication(conditions)
+    super(conditions.merge(:deleted_flg => "false"))
+  end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,8 @@ class User < ActiveRecord::Base
 
   validates_presence_of :name
 
+  scope :active, -> { where(deleted_flg: false) }
+
   def favorite?(question)
     favorites.find_by(question_id: question.id)
   end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -8,57 +8,57 @@
     </ul>
   </div>
   <div class="col-sm-8">
-  <h2>プロフィールを編集</h2>
-  <hr>
-  <h3>公開情報</h3>
-  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-    <%= devise_error_messages! %>
-    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-      <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-    <% end %>
-    <div class="row">
-      <div class="col-sm-4">
-        <div class="field">
-          <%= avatar_lg(@user) %>
-          <%= f.label :"User画像の変更" %><br>
-          <%= f.file_field :avatar %>
-          <%= f.hidden_field :avatar_cache %>
-        </div>
-      </div>
-      <div class="col-sm-5 col-sm-offset-1">
-        <div class="field">
-          <%= f.label :"表示名" %>
-          <%= f.text_field :name, class: "form-control", placeholder: "表示名" %>
-        </div>
-      </div>
-    </div>
-    <div class="field">
-      <%= f.label :"自己紹介" %>
-      <%= f.text_area :profile, autocomplete: "off", class: "form-control", placeholder: "自己紹介" %>
-    </div>
+    <h2>プロフィールを編集</h2>
     <hr>
-    <h3>非公開情報</h3>
-    <div class="field">
-      <%= f.label :"メールアドレス" %><br />
-      <%= f.email_field :email, class: "form-control" %>
-    </div>
-    <div class="field">
-      <strong class="text-danger">パスワードを変更しない場合は「新しいパスワード」と「新しいパスワード(確認用)」をブランクにしてください。</strong><br>
-      <%= f.label :"新しいパスワード" %>
-      <%= f.password_field :password, autocomplete: "off", class: "form-control", placeholder: "新しいパスワード" %>
-    </div>
-    <div class="field">
-      <%= f.label :"新しいパスワード(確認用)" %>
-      <%= f.password_field :password_confirmation, autocomplete: "off", class: "form-control", placeholder: "新しいパスワード(確認用)" %>
-    </div>
-    <div class="field">
-      <%= f.label :"現在のパスワード" %>
-      <strong class="text-danger">(User情報を変更する場合は、下に現在のパスワードを入力してください。)</strong><br>
-      <%= f.password_field :current_password, autocomplete: "off", class: "form-control", placeholder: "現在のパスワード(current password)"  %>
-    </div>
-    <div class="field">
-      <%= f.submit "更新", class: "btn btn-primary btn-block" %>
-    </div>
-  <% end %>
+    <h3>公開情報</h3>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+      <%= devise_error_messages! %>
+      <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+        <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+      <% end %>
+      <div class="row">
+        <div class="col-sm-4">
+          <div class="field">
+            <%= avatar_lg(@user) %>
+            <%= f.label :"User画像の変更" %><br>
+            <%= f.file_field :avatar %>
+            <%= f.hidden_field :avatar_cache %>
+          </div>
+        </div>
+        <div class="col-sm-5 col-sm-offset-1">
+          <div class="field">
+            <%= f.label :"表示名" %>
+            <%= f.text_field :name, class: "form-control", placeholder: "表示名" %>
+          </div>
+        </div>
+      </div>
+      <div class="field">
+        <%= f.label :"自己紹介" %>
+        <%= f.text_area :profile, autocomplete: "off", class: "form-control", placeholder: "自己紹介" %>
+      </div>
+      <hr>
+      <h3>非公開情報</h3>
+      <div class="field">
+        <%= f.label :"メールアドレス" %><br />
+        <%= f.email_field :email, class: "form-control" %>
+      </div>
+      <div class="field">
+        <strong class="text-danger">パスワードを変更しない場合は「新しいパスワード」と「新しいパスワード(確認用)」をブランクにしてください。</strong><br>
+        <%= f.label :"新しいパスワード" %>
+        <%= f.password_field :password, autocomplete: "off", class: "form-control", placeholder: "新しいパスワード" %>
+      </div>
+      <div class="field">
+        <%= f.label :"新しいパスワード(確認用)" %>
+        <%= f.password_field :password_confirmation, autocomplete: "off", class: "form-control", placeholder: "新しいパスワード(確認用)" %>
+      </div>
+      <div class="field">
+        <%= f.label :"現在のパスワード" %>
+        <strong class="text-danger">(User情報を変更する場合は、下に現在のパスワードを入力してください。)</strong><br>
+        <%= f.password_field :current_password, autocomplete: "off", class: "form-control", placeholder: "現在のパスワード(current password)"  %>
+      </div>
+      <div class="field">
+        <%= f.submit "更新", class: "btn btn-primary btn-block" %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -4,7 +4,7 @@
   <div class="col-sm-4">
     <ul class="nav nav-pills nav-stacked">
       <li><%= link_to 'プロフィール', edit_user_registration_path %></li>
-      <li><%= link_to "削除", registration_path(resource_name), data: { confirm: "本当に削除しますか？" }, method: :delete %></li> <%#  TODO n.uchiyama 関連レコードがある状態でuserを物理削除出来ないのでuserも論理削除に変える。%>
+      <li><%= link_to "削除", registration_path(resource_name), data: { confirm: "本当に削除しますか？" }, method: :delete %></li>
     </ul>
   </div>
   <div class="col-sm-8">

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -74,6 +74,8 @@ ja:
 #      signed_in: 'Signed in successfully.'
       signed_out: 'ログアウトしました。'
 #      signed_out: 'Signed out successfully.'
+      user:
+        sign_out_after_deleted: 'ユーザーアカウントを削除しました。'
     unlocks:
       send_instructions: 'アカウントの凍結解除方法を数分以内にメールでご連絡します。'
 #      send_instructions: 'You will receive an email with instructions about how to unlock your account in a few minutes.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
     :registrations => 'users/registrations'
   }
   devise_scope :user do
-    get 'users/delete_sign_out' => 'users/sessions#destroy'
+    get '/users/delete_sign_out' => 'users/sessions#destroy'
   end
   resources :users, only: [:index, :show] do
     member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
     :registrations => 'users/registrations'
   }
   devise_scope :user do
-    get '/users/sign_out' => 'devise/sessions#destroy'
+    get 'users/delete_sign_out' => 'users/sessions#destroy'
   end
   resources :users, only: [:index, :show] do
     member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,14 +11,20 @@ Rails.application.routes.draw do
       get 'tagged'
     end
   end
-  devise_for :users
+  devise_for :users, :controllers => {
+    :registrations => 'users/registrations'
+  }
+  devise_scope :user do
+    get '/users/sign_out' => 'devise/sessions#destroy'
+  end
   resources :users, only: [:index, :show] do
     member do
       get 'favorite'
     end
   end
-  
+
   resources :tags,  only: [:index]
+
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 


### PR DESCRIPTION
Issues#111
Userアカウントの削除を論理削除に変更
stack overflowの仕様(http://ja.stackoverflow.com/help/deleting-account)を参考に下記の様な仕様にした。
+ 削除されたアカウントは匿名ユーザーとなり、質問と回答は残す。
+ 匿名ユーザーの投票は論理削除し質問、回答の投票数をカウントを減らす。(Userのスコアはそのまま)
+ 削除されたアカウントではログイン出来ない。
+ 削除されたユーザーの写真、名前等のプロフィールはクリアする。
+ 削除されたアカウントはユーザー一覧に表示されない。
+ 削除されたアカウントと同じメールアドレスで再登録が出来る。