### PR TITLE
【Fixed】質問と回答を論理削除する際の関連テーブルの論理削除

### DIFF
--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,4 +1,6 @@
 class Favorite < ActiveRecord::Base
   belongs_to :question
   belongs_to :user
+
+  default_scope -> { where(deleted_flg: false) }
 end

--- a/app/models/tag_relation.rb
+++ b/app/models/tag_relation.rb
@@ -1,4 +1,6 @@
 class TagRelation < ActiveRecord::Base
   belongs_to :question
   belongs_to :tag
+
+  default_scope -> { where(deleted_flg: false) }
 end

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -2,4 +2,6 @@ class Vote < ActiveRecord::Base
   belongs_to :answer
   belongs_to :question
   belongs_to :user
+
+  default_scope -> { where(deleted_flg: false) }
 end


### PR DESCRIPTION
Issues#165
質問と回答を論理削除する際に関連テーブルも論理削除を行う。

質問削除
+ favorites
+ tag_relations
+ votes
+ answers
+ answersに対するvotes
回答削除
+ votes

