### PR TITLE
【FIxed】マイページの日時フォーマット修正

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -59,7 +59,7 @@
                     <i class="fa fa-question-circle-o fa-lg"></i>
                     <div class="btn-xs btn-success question_score"><%= question.posi_counts - question.nega_counts %></div>
                     <div class="question_heading"><%= link_to truncate(question.title, length: 30), question %></div>
-                    <div class="question_time"><%= question.created_at.to_s(:ymd) %></div>
+                    <div class="question_time"><%= question.created_at.to_s(:ymd_and_HM2) %></div>
                 </div>
             <% end %>
         <% end %>
@@ -72,7 +72,7 @@
                     <i class="fa fa-comment-o fa-lg"></i>
                     <div class="btn-xs btn-success answer_score"><%= answer.posi_counts - answer.nega_counts %></div>
                     <div class="answer_heading"><%= link_to truncate(answer.content, length: 30), answer.question %></div>
-                    <div class="answer_time"><%= answer.created_at.to_s(:ymd) %></div>
+                    <div class="answer_time"><%= answer.created_at.to_s(:ymd_and_HM2) %></div>
                 </div>
             <% end %>
         <% end %>

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -7,4 +7,5 @@
 # カスタムフォーマットを定義
 Time::DATE_FORMATS[:md_and_HM] = "%-m月%e日 %k:%M"
 Time::DATE_FORMATS[:ymd_and_HM] = "%Y年%-m月%e日 %H時%M分"
+Time::DATE_FORMATS[:ymd_and_HM2] = "%y年%-m月%e日 %H:%M"
 Time::DATE_FORMATS[:ymd] = "%y年%-m月%e日"


### PR DESCRIPTION
issues#166

マイページのプロフィールにある質問、回答一覧の新着順タブを押下した際に
時刻が表示されていないので新着順になっているかが分からない。
フォーマットを変更し日時を表示する様にする。